### PR TITLE
Implement custom words and polish word reveal

### DIFF
--- a/client/src/Canvas.js
+++ b/client/src/Canvas.js
@@ -87,7 +87,9 @@ const Canvas = forwardRef((props, ref) => {
 
       ctx.font = "50px Comic Sans MS, cursive, TSCu_Comic, sans-serif"; 
       let dashLen = 220, dashOffset = dashLen, speed = 11, i = 0;
-      let x = (ctx.canvas.width / 2) - Math.floor((ctx.measureText(txt).width + ctx.lineWidth) / 2);
+      let x = (ctx.canvas.width / 2) - Math.floor((ctx.measureText(txt).width + ctx.lineWidth * txt.length) / 2);
+
+      if (txt.length >= 10) speed = Math.max(2, speed - 2 * (11 - txt.length));
 
       (function loop() {
         ctx.setLineDash([dashLen - dashOffset, dashOffset - speed]);

--- a/client/src/Game.js
+++ b/client/src/Game.js
@@ -65,6 +65,7 @@ const Game = props => {
     };
 
     const onShowScore = data => {
+      // TODO: It seems this causes some of the painter's first strokes not to appear when tabbed away
       canvasRef.current.showScore(data.word);
     };
 

--- a/client/src/Lobby.js
+++ b/client/src/Lobby.js
@@ -4,6 +4,8 @@ import React, { useEffect, useState } from "react";
 
 const Lobby = props => {
   const [nRounds, setNRounds] = useState(10);
+  const [customWords, setCustomWords] = useState('');
+  const [customWordChance, setCustomWordChance] = useState(50);
 
   const [customRounds, setCustomRounds] = useState(false);
   const [drawTime, setDrawTime] = useState(10);
@@ -13,10 +15,12 @@ const Lobby = props => {
   useEffect(() => {
     const settingChanged = (name, value) => {
       if (name === 'nRounds') setNRounds(value);
+      else if (name === 'customWordChance') setCustomWordChance(value);
       else if (name === 'customRounds') setCustomRounds(value);
       else if (name === 'drawTime') setDrawTime(value);
       else if (name === 'minimumInk') setMinimumInk(value);
       else if (name === 'maximumInk') setMaximumInk(value);
+      // TODO: Should this also accept customWords?
     }
 
     props.socket.on('setting_changed', settingChanged);
@@ -49,7 +53,8 @@ const Lobby = props => {
   const isLeader = props.players[0] && props.players[0][0] === props.selfId;
   function handleSubmit(e) {
     e.preventDefault();
-    if (isLeader) props.socket.emit('start_room', { nRounds, customRounds, drawTime, minimumInk, maximumInk });
+    if (isLeader) props.socket.emit('start_room',
+      { nRounds, customWords, customWordChance, customRounds, drawTime, minimumInk, maximumInk });
   }
 
   function onKeyPress(e) {
@@ -116,7 +121,15 @@ const Lobby = props => {
             <div className="setting">
               <label htmlFor="custom-words">Custom words</label>
               <textarea name="custom-words" id="custom-words" rows="6"
-                placeholder="Type a list of custom words here, separated by commas" disabled={ !isLeader }></textarea>
+                value={ customWords } onChange={ (e) => setCustomWords(e.target.value) }
+                placeholder="Type a list of custom words here, separated by commas (max word length is 16 characters)"
+                disabled={ !isLeader }></textarea>
+            </div>
+            <div className="setting">
+              <label htmlFor="custom-word-chance">Custom word chance (%)</label>
+              <input type="number" name="custom-word-chance" id="custom-word-chance" value={ customWordChance }
+                onChange={ (e) => changeNumber(e, setCustomWordChance, 'customWordChance') }
+                min="0" max="100" required disabled={ !isLeader }></input>
             </div>
 
             <div className="custom-rounds-area">

--- a/src/room.js
+++ b/src/room.js
@@ -48,6 +48,8 @@ module.exports = class Room {
 
     this.round = 1; // 1-indexed
     this.nRounds = 0; // Same meaning as the frontend - nRounds=5 means round=5 is the last round
+    this.customWords = [];
+    this.customWordChance = 50;
     this.drawTime = null;
     this.minimumInk = null;
     this.maximumInk = null;
@@ -169,7 +171,8 @@ module.exports = class Room {
 
     this.customWords = String(settings.customWords || '')
       .replace(/\s/g, ' ').split(',').map((s) => s.trim()) // Extract individual phrases
-      .filter(s => s.length > 0 && s.length <= maxCustomWordLength);
+      .filter(s => s.length > 0 && s.length <= maxCustomWordLength)
+      .slice(0, 1000);
     let _customWordChance = Number(settings.customWordChance);
     if (isNaN(_customWordChance)) _customWordChance = 50;
     this.customWordChance = Math.max(0, Math.min(100, _customWordChance));


### PR DESCRIPTION
- Custom words
    - Added two new settings to the lobby: "Custom words" and "Custom word chance"
    - Custom words are a comma-separated list
        - Words are filtered so they have length in [1, 16]
    - Each round, the word choice algorithm is now as follows:
        - If the custom words list is non-empty and Math.random() <= (customWordChance / 100):
            - If there is only one custom word (edge case), pick it
            - Otherwise, pick a word that is not the previous round's word
        - Else, pick a random official word that is not the previous round's word
    - For security, there is a maximum of 1000 custom words
- Improve word reveal on score screen
    - The drawing of the word will be faster if the word is longer than 9 characters
        - Each character beyond that will increase the speed, up to a maximum speed
    - Words are now properly centered thanks to a bug fix
        - Previously, the offset only took into account the stroke width of a single stroke, but it now accounts for all characters' thickness